### PR TITLE
Add dist publishing step to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /data/config-internal-override.php
 /data/tmp/*
 /build
+/dist
 /node_modules
 /npm-debug.log
 /test.php

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,6 +162,7 @@ module.exports = grunt => {
                 'client/lib/*',
                 'client/modules/crm/lib/*',
                 'client/css/espo/*',
+                'dist',
             ],
             final: ['build/tmp'],
             release: ['build/EspoCRM-' + pkg.version],
@@ -259,6 +260,13 @@ module.exports = grunt => {
                 src: '**',
                 cwd: 'build/tmp',
                 dest: 'build/EspoCRM-<%= pkg.version %>/',
+            },
+            dist: {
+                expand: true,
+                dot: true,
+                src: '**',
+                cwd: 'build/EspoCRM-<%= pkg.version %>/',
+                dest: 'dist/',
             },
         },
 
@@ -544,6 +552,7 @@ module.exports = grunt => {
         'copy:final',
         'chmod-folders',
         'chmod-multiple',
+        'copy:dist',
         'clean:final',
     ];
 


### PR DESCRIPTION
## Summary
- extend the Grunt build to copy the packaged application into a `dist` directory and clean any previous output so Netlify can publish it
- ignore the generated `dist` folder so build artifacts are not committed

## Testing
- npx grunt offline

------
https://chatgpt.com/codex/tasks/task_e_68c87a6fd7d483299591566af37c0525