### PR TITLE
Ensure Netlify build outputs dist directory

### DIFF
--- a/js/scripts/create-dist.js
+++ b/js/scripts/create-dist.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '../..');
+const pkg = require(path.join(rootDir, 'package.json'));
+
+const buildDirName = `EspoCRM-${pkg.version}`;
+const sourceDir = path.join(rootDir, 'build', buildDirName);
+const distDir = path.join(rootDir, 'dist');
+
+if (!fs.existsSync(sourceDir)) {
+    console.error(`Build output directory '${path.relative(rootDir, sourceDir)}' was not found.`);
+    process.exit(1);
+}
+
+if (fs.existsSync(distDir)) {
+    fs.rmSync(distDir, {recursive: true, force: true});
+}
+
+fs.cpSync(sourceDir, distDir, {recursive: true});
+
+console.log(`Copied '${path.relative(rootDir, sourceDir)}' to '${path.relative(rootDir, distDir)}'.`);
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "postinstall": "node js/scripts/postinstall-cleanup && node js/scripts/prepare-lib-original.js",
-    "build": "grunt",
+    "build": "npx grunt && node js/scripts/create-dist.js",
     "build-dev": "grunt dev",
     "build-test": "grunt test",
     "build-frontend": "grunt internal",


### PR DESCRIPTION
## Summary
- update the npm build script to run Grunt through `npx` and then mirror the packaged output into a `dist` folder
- add a helper script that copies the generated `build/EspoCRM-<version>` directory into `dist` so Netlify can publish it

## Testing
- npm run build *(fails in this container: `npx rollup ... Could not resolve entry module "node_modules/@shopify/draggable/build/esm/index.mjs"`)*

------
https://chatgpt.com/codex/tasks/task_e_68c87a6fd7d483299591566af37c0525