### PR TITLE
Ensure build outputs dist directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /data/config-internal-override.php
 /data/tmp/*
 /build
+/dist
 /node_modules
 /npm-debug.log
 /test.php

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -163,6 +163,7 @@ module.exports = grunt => {
                 'client/modules/crm/lib/*',
                 'client/css/espo/*',
             ],
+            dist: ['dist'],
             final: ['build/tmp'],
             release: ['build/EspoCRM-' + pkg.version],
             beforeFinal: {src: cleanupBeforeFinal},
@@ -259,6 +260,13 @@ module.exports = grunt => {
                 src: '**',
                 cwd: 'build/tmp',
                 dest: 'build/EspoCRM-<%= pkg.version %>/',
+            },
+            dist: {
+                expand: true,
+                dot: true,
+                src: '**',
+                cwd: 'build/EspoCRM-<%= pkg.version %>/',
+                dest: 'dist/',
             },
         },
 
@@ -535,6 +543,7 @@ module.exports = grunt => {
 
     const offline = [
         'clean:start',
+        'clean:dist',
         'mkdir:tmp',
         'internal',
         'copy:frontend',
@@ -544,6 +553,7 @@ module.exports = grunt => {
         'copy:final',
         'chmod-folders',
         'chmod-multiple',
+        'copy:dist',
         'clean:final',
     ];
 


### PR DESCRIPTION
## Summary
- add dist clean/copy targets to the Grunt build so packaged files are duplicated into a publishable folder
- run the new dist step as part of the offline build pipeline used by npm run build
- ignore the generated dist directory in version control

## Testing
- PUPPETEER_SKIP_DOWNLOAD=1 npm run build


------
https://chatgpt.com/codex/tasks/task_e_68c87a6fd7d483299591566af37c0525