### PR TITLE
Add Netlify deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ We highly recommend using an IDE for development. The backend codebase follows S
 
 Metadata plays an integral role in the EspoCRM application. All possible parameters are described with a JSON Schema, meaning you will have autocompletion in the IDE. You can also find the full metadata reference in the documentation.
 
+### Netlify deployment helpers
+
+The repository includes a `netlify.toml` configuration together with `_redirects` and `_headers` files in the `public/` directory. These files ensure that Netlify processes redirect and header rules during deployment. A sample on-demand function is available at `/.netlify/functions/health-check`, and a security-focused edge function automatically appends standard security headers to outgoing responses. If you are deploying EspoCRM to Netlify, make sure the `public/` directory is used as the publish directory so that these rules and functions are detected.
+
 ### Community & Support
 
 If you have a question regarding some features, need help or customizations, want to get in touch with other EspoCRM users, or add a feature request, please use our [community forum](https://forum.espocrm.com/). We believe that using the forum to ask for help and share experience allows everyone in the community to contribute and use this knowledge later.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,32 @@
+[build]
+  command = "npm run build"
+  publish = "public"
+
+[functions]
+  directory = "netlify/functions"
+
+[edge_functions]
+  directory = "netlify/edge-functions"
+
+[[edge_functions]]
+  function = "security-headers"
+  path = "/*"
+
+[[redirects]]
+  from = "/api/status"
+  to = "/.netlify/functions/health-check"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/*"
+  to = "/index.php"
+  status = 200
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "geolocation=(), microphone=(), camera=()"

--- a/netlify/edge-functions/security-headers.js
+++ b/netlify/edge-functions/security-headers.js
@@ -1,0 +1,14 @@
+export default async function securityHeaders(request, context) {
+  const response = await context.next();
+
+  response.headers.set('X-Frame-Options', 'SAMEORIGIN');
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  response.headers.set('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
+
+  return response;
+}
+
+export const config = {
+  path: '/*'
+};

--- a/netlify/functions/health-check.js
+++ b/netlify/functions/health-check.js
@@ -1,0 +1,16 @@
+exports.handler = async () => {
+  const timestamp = new Date().toISOString();
+  const payload = {
+    status: 'ok',
+    application: 'EspoCRM',
+    checkedAt: timestamp
+  };
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  };
+};

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/*
+  X-Frame-Options: SAMEORIGIN
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+/api/status /.netlify/functions/health-check 200!
+/* /index.php 200


### PR DESCRIPTION
## Summary
- add a Netlify configuration file with redirect, header, and function definitions so deploy summaries show processed rules
- provide sample serverless and edge functions to expose a health-check endpoint and set security headers
- document how to leverage the Netlify helpers when deploying EspoCRM

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c8814bcee083299483c178e7166d40