### PR TITLE
fix: harden netlify configuration parsing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
   publish = "public"
   command = "npm run build"
+  edge_functions = "netlify/edge-functions"
 
 [functions]
   directory = "netlify/functions"
@@ -18,15 +19,15 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
-    X-Content-Type-Options = "nosniff"
-    Referrer-Policy = "strict-origin-when-cross-origin"
-    X-Frame-Options = "DENY"
+    "Strict-Transport-Security" = "max-age=63072000; includeSubDomains; preload"
+    "X-Content-Type-Options" = "nosniff"
+    "Referrer-Policy" = "strict-origin-when-cross-origin"
+    "X-Frame-Options" = "DENY"
 
 [[headers]]
   for = "/assets/*"
   [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"
+    "Cache-Control" = "public, max-age=31536000, immutable"
 
 [[edge_functions]]
   path = "/edge-health"


### PR DESCRIPTION
## Summary
- add explicit edge functions directory configuration to the Netlify build block
- quote header map keys to avoid potential parsing issues in the Netlify config

## Testing
- npx @netlify/config

------
https://chatgpt.com/codex/tasks/task_e_68c885e70a3483299678460e7ad1f5cc