### PR TITLE
Define Netlify edge functions directory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,9 @@
 [dev]
   functions = "netlify/functions"
 
+[edge_functions]
+  directory = "netlify/edge-functions"
+
 [[redirects]]
   from = "/healthz"
   to = "/.netlify/functions/health-check"


### PR DESCRIPTION
## Summary
- declare the Netlify edge functions directory in netlify.toml so the config parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c885e70a3483299678460e7ad1f5cc