### PR TITLE
Clarify Netlify compatibility layer documentation

### DIFF
--- a/docs/deployment/netlify.md
+++ b/docs/deployment/netlify.md
@@ -6,33 +6,35 @@ there is no generated `index.html` or PHP runtime available, Netlify cannot exec
 
 ## Compatibility layer for deploy previews
 
-Starting from this repository version we ship a small Netlify compatibility layer that makes the limitation explicit:
+Starting from this repository version we ship a small Netlify compatibility layer that makes the limitation explicit so
+people opening a deploy preview see guidance instead of an error page.
 
-* `netlify.toml` adds a catch-all redirect to `/netlify-not-supported.html`, applies security headers, and exposes a
-  simple serverless function that reports the unsupported status.
-* `netlify/functions/status.js` responds with JSON so the deploy summary shows a function being provisioned.
-* `netlify/edge-functions/netlify-notice.js` decorates the compatibility page with an `X-EspoCRM-Netlify` header to
-  demonstrate an edge function invocation.
-* `public/netlify-not-supported.html` is the static page Netlify serves instead of a confusing 404. It links back to
-  this documentation for the recommended hosting options.
-
-These files do not make EspoCRM runnable on Netlify—they only explain the limitation to people opening the deploy
-preview. The application still needs to be hosted on infrastructure that provides PHP and a supported database.
+This compatibility layer does not make EspoCRM runnable on Netlify—it only explains the limitation to people opening the
+deploy preview. The application still needs to be hosted on infrastructure that provides PHP and a supported database.
 
 ## Understanding the Netlify deploy summary
 
-With the compatibility layer in place, the Netlify deploy summary now lists a processed redirect, security headers, a
-provisioned serverless function, and a single edge function. Those entries exist purely so the preview clearly indicates
-that Netlify is not a supported hosting option for EspoCRM. They do not change the underlying requirement for PHP and a
-persistent database.
+The compatibility layer components map directly to the entries Netlify reports after each deploy:
+
+* The catch-all redirect defined in `netlify.toml` points every request to `/netlify-not-supported.html`, so visitors land
+  on the notice page instead of encountering a 404. This shows up in the summary as a processed redirect.
+* The `/netlify-status` route forwards to `netlify/functions/status.js`, a serverless function that returns JSON
+  explaining that EspoCRM requires a PHP runtime with a supported database. Netlify records this as the deployed
+  function.
+* `netlify/edge-functions/netlify-notice.js` runs whenever the notice page is served, adds an `X-EspoCRM-Netlify`
+  response header, and disables caching, which is why the summary includes an edge function entry.
+* `public/netlify-not-supported.html` provides the notice itself, linking back to this documentation and recommended
+  hosting targets. It is the page every preview visitor ultimately sees.
+
+These items only document the limitation; they do not add PHP support or remove the requirement for a persistent
+database.
 
 ## Recommended approaches
 
 * Deploy EspoCRM to infrastructure that provides a PHP 8.2–8.4 runtime together with a supported database such as
   MySQL, MariaDB, or PostgreSQL. You can follow the standard installation options that use those requirements,
   including manual, scripted, or Docker-based setups described in the main README.
-* If you need a managed hosting solution, choose a provider that offers PHP and database support. Netlify cannot serve the
-  application because it does not execute PHP code.
+* Choose a managed hosting provider that offers PHP and database support. Netlify cannot serve the application because it does not execute PHP code.
 * For local evaluation, use the documented installation workflows to provision a compatible environment before migrating
   to production hosting.
 


### PR DESCRIPTION
## Summary
- describe the Netlify compatibility layer components in the deploy summary section, covering the redirect, status function, edge function, and notice page
- clarify that the compatibility layer only informs visitors and does not add PHP support, and tidy the managed hosting guidance sentence

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c8db4b2a98832981cce9c482ebc449