### PR TITLE
Align cache-control for Netlify notice page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -39,7 +39,7 @@
 [[headers]]
   for = "/netlify-not-supported.html"
   [headers.values]
-    "Cache-Control" = "no-store"
+    "Cache-Control" = "no-cache, no-store, must-revalidate"
 
 [[edge_functions]]
   path = "/netlify-not-supported.html"

--- a/netlify/edge-functions/netlify-notice.js
+++ b/netlify/edge-functions/netlify-notice.js
@@ -2,7 +2,6 @@ export default async function handler(request, context) {
   const response = await context.next();
 
   response.headers.set('X-EspoCRM-Netlify', 'unsupported');
-  response.headers.set('Cache-Control', 'no-cache, no-store, must-revalidate');
 
   return response;
 }


### PR DESCRIPTION
## Summary
- set the `/netlify-not-supported.html` cache-control header to `no-cache, no-store, must-revalidate` in `netlify.toml`
- remove the duplicate cache-control header assignment from the `netlify-notice` edge function so the policy is managed in a single place

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8db5859cc83298f65ea3b5140ba36